### PR TITLE
PO-Revision-Date を自動更新しない設定(Emacs po-modeにて)

### DIFF
--- a/org-ja.po
+++ b/org-ja.po
@@ -1,3 +1,4 @@
+# -*- po-auto-replace-revision-date: nil; -*-
 # SOME DESCRIPTIVE TITLE
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.


### PR DESCRIPTION
## 動機

マージの際に、日付部分のコンフリクトへ対応するのが面倒でした。
## 副作用の確認

このコミットの前後で以下の比較をしました。
Poedit でorg-ja.poを開き、ウィンドウ下部のステータスバーのメッセージを比較しました。いずれの場合も、以下の通りでした。

> 52 %翻訳されています、4105の文字列(1969個が未確定)

なお、Poedit で保存すると、PO-Revision-Date は自動更新されます。
